### PR TITLE
Fix compiling with Xcode 12

### DIFF
--- a/build_mmh3cffi.py
+++ b/build_mmh3cffi.py
@@ -10,7 +10,7 @@ HEADER = 'uint32_t murmurhash3_32_x86(const unsigned char* key, int len, int32_t
 FFI_BUILDER.cdef(HEADER)
 FFI_BUILDER.set_source(
     'mmh3cffi._cimpl',
-    '',
+    '#include "mmh3.h"',
     sources=[os.path.join('csrc', 'mmh3.c')],
     include_dirs=['csrc']
 )

--- a/csrc/mmh3.c
+++ b/csrc/mmh3.c
@@ -1,7 +1,5 @@
 #include "stdint.h"
 
-uint32_t murmurhash3_32_x86(const unsigned char* key, int len, int32_t seed);
-
 inline uint32_t rotl32(uint32_t x, int8_t r) {
     return (x << r) | (x >> (32 - r));
 }

--- a/csrc/mmh3.h
+++ b/csrc/mmh3.h
@@ -1,0 +1,1 @@
+uint32_t murmurhash3_32_x86(const unsigned char* key, int len, int32_t seed);


### PR DESCRIPTION
Compiling with clang/Xcode 12 on macOS was erroring out with:

```
    clang -Wno-unused-result -Wsign-compare -Wunreachable-code -fno-common -dynamic -DNDEBUG -g -fwrapv -O3 -Wall -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX10.15.sdk -I/Library/Developer/CommandLineTools/SDKs/MacOSX10.15.sdk/usr/include -I/Library/Developer/CommandLineTools/SDKs/MacOSX10.15.sdk/System/Library/Frameworks/Tk.framework/Versions/8.5/Headers -Icsrc -I/usr/local/include -I/usr/local/opt/openssl@1.1/include -I/usr/local/opt/sqlite/include -I/Users/travis/build/GoodRx/gold/.tox/py38/include -I/usr/local/opt/python@3.8/Frameworks/Python.framework/Versions/3.8/include/python3.8 -c build/temp.macosx-10.15-x86_64-3.8/mmh3cffi._cimpl.c -o build/temp.macosx-10.15-x86_64-3.8/build/temp.macosx-10.15-x86_64-3.8/mmh3cffi._cimpl.o
    build/temp.macosx-10.15-x86_64-3.8/mmh3cffi._cimpl.c:556:10: error: implicit declaration of function 'murmurhash3_32_x86' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
      return murmurhash3_32_x86(x0, x1, x2);
             ^
    build/temp.macosx-10.15-x86_64-3.8/mmh3cffi._cimpl.c:595:14: error: implicit declaration of function 'murmurhash3_32_x86' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
      { result = murmurhash3_32_x86(x0, x1, x2); }
                 ^
    2 errors generated.
    error: command 'clang' failed with exit status 1
```

This is because of a change in clang in Xcode 12:

> Clang now reports an error when you use a function without an explicit declaration when building C or Objective-C code for macOS (`-Werror=implicit-function-declaration` flag is on). This additional error detection unifies Clang’s behavior for iOS/tvOS and macOS 64-bit targets for this diagnostic. (49917738)

This patch fixes that by following the setup in the CFFI docs for [API Mode, calling C sources instead of a compiled library](https://cffi.readthedocs.io/en/latest/overview.html#api-mode-calling-c-sources-instead-of-a-compiled-library).