### PR TITLE
Remove dependency on `future`

### DIFF
--- a/mmh3cffi/__init__.py
+++ b/mmh3cffi/__init__.py
@@ -1,5 +1,4 @@
 """Python frontend for the C implementation of murmurhash3."""
-from builtins import bytes
 from mmh3cffi._cimpl import ffi, lib
 
 def hash_str(to_hash, seed=0):

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     url='https://github.com/splitio/mmh3cffi',
     packages=find_packages(exclude=['test, csrc']),
     setup_requires=['cffi>=1.4.0', 'pytest-runner'],
-    install_requires=['cffi>=1.4.0', 'future'],
+    install_requires=['cffi>=1.4.0'],
     tests_require=['pytest'],
     cffi_modules=['build_mmh3cffi.py:FFI_BUILDER']
 )


### PR DESCRIPTION
`from builtins import bytes` was never actually used.